### PR TITLE
Shell: Fix bug on Windows shells

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// Set DEBUG var here for compatibility with Windows shells
+process.env.DEBUG = 'express:*,light-api:*'
+
 const bodyParser = require('body-parser')
 const express = require('express')
 const _ = require('lodash')

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "light-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A proxy API for a home automation light control system",
   "main": "index.js",
   "scripts": {
-    "start": "DEBUG=express:*,light-api:* node index.js",
+    "start": "node index.js",
     "test": "eslint index.js && mocha test --exit"
   },
   "author": "",


### PR DESCRIPTION
- Set DEBUG env var in node runtime instead of shell command

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>